### PR TITLE
Use separate session for oauth login and regular login

### DIFF
--- a/_dependencies.php
+++ b/_dependencies.php
@@ -41,8 +41,29 @@ use League\OAuth2\Server\Grant\AuthCodeGrant;
 use League\OAuth2\Server\Grant\RefreshTokenGrant;
 use League\OAuth2\Server\ResourceServer;
 use Psr\Container\ContainerInterface;
+use RKA\SessionMiddleware;
 
 $container = $app->getContainer();
+
+//$app->add($session);
+$container->set(
+    'oauth_session',
+    function (ContainerInterface $container) {
+        $session_name = PREFIX_DB . '_' . NAME_DB . '_' . str_replace('.', '_', GALETTE_VERSION);
+        $session_name = 'galette_oauth_' . $session_name;
+        $session = new SessionMiddleware([
+            'name'      => $session_name,
+            'lifetime'  => GALETTE_TIMEOUT
+        ]);
+
+        $galette_sid = session_id();
+        session_write_close();
+        session_id('galette-oauth-' . $galette_sid);
+        $session->start();
+
+        return new \RKA\Session();
+    }
+);
 
 $container->set(
     Config::class,

--- a/_dependencies.php
+++ b/_dependencies.php
@@ -36,16 +36,11 @@ use GaletteOAuth2\Repositories\RefreshTokenRepository;
 use GaletteOAuth2\Repositories\ScopeRepository;
 use GaletteOAuth2\Repositories\UserRepository;
 use GaletteOAuth2\Tools\Config;
-use GaletteOAuth2\Tools\Debug as Debug;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Grant\AuthCodeGrant;
 use League\OAuth2\Server\Grant\RefreshTokenGrant;
 use League\OAuth2\Server\ResourceServer;
 use Psr\Container\ContainerInterface;
-
-if (OAUTH2_LOG) {
-    Debug::init();
-}
 
 $container = $app->getContainer();
 

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
         {
             "name": "Manuel H",
             "email": "manuelh78dev@ik.me"
+        }, {
+            "name": "Johan Cwiklinski",
+            "email": "trasher@x-tnd.be"
         }
     ],
     "require": {

--- a/lib/GaletteOAuth2/Authorization/UserHelper.php
+++ b/lib/GaletteOAuth2/Authorization/UserHelper.php
@@ -125,9 +125,6 @@ final class UserHelper
         '.' .
         self::stripAccents($nameFPart);
 
-        //FIXME: is that really useful? From a Galette PoV; this does not means much.
-        $etat_adhesion = ($member->isActive() && $member->isUp2Date()) || $member->isAdmin();
-
         if (!$member->isActive()) {
             throw new UserAuthorizationException(_T('You are not an active member.', 'oauth2'));
         }
@@ -216,7 +213,6 @@ final class UserHelper
             'phone' => $phone,
 
             'status' => $member->status,
-            'state' => $etat_adhesion ? 'true' : 'false',
             'groups' => $groups, //nextcloud : set fields Groups claim (optional) = groups
         ];
     }

--- a/lib/GaletteOAuth2/Authorization/UserHelper.php
+++ b/lib/GaletteOAuth2/Authorization/UserHelper.php
@@ -185,7 +185,7 @@ final class UserHelper
         }
         $groups = implode(',', $groups);
 
-        $phone = '';
+        /*$phone = '';
         if ($member->phone) {
             $phone = $member->phone;
         }
@@ -194,7 +194,7 @@ final class UserHelper
                 $phone .= '/';
             }
             $phone .= $member->gsm;
-        }
+        }*/
 
         return [
             'id' => $member->id,
@@ -207,10 +207,10 @@ final class UserHelper
             'mail' => $member->email,
             'language' => $member->language,
 
-            'country' => $member->country,
+            /*'country' => $member->country,
             'zip' => $member->zipcode,
             'city' => $member->town,
-            'phone' => $phone,
+            'phone' => $phone,*/
 
             'status' => $member->status,
             'groups' => $groups, //nextcloud : set fields Groups claim (optional) = groups

--- a/lib/GaletteOAuth2/Authorization/UserHelper.php
+++ b/lib/GaletteOAuth2/Authorization/UserHelper.php
@@ -44,7 +44,7 @@ final class UserHelper
         /** @var Login $login */
         $login = $container->get('login');
         $history = $container->get('history');
-        $session = $container->get('session');
+        $session = $container->get('oauth_session');
         $flash = $container->get('flash');
 
         if (trim($nick) === '' || trim($password) === '') {
@@ -90,7 +90,7 @@ final class UserHelper
         /** @var Login $login */
         $login = $container->get('login');
         $history = $container->get('history');
-        $session = $container->get('session');
+        $session = $container->get('oauth_session');
 
         $login->logout();
         $session->login = $login;

--- a/lib/GaletteOAuth2/Authorization/UserHelper.php
+++ b/lib/GaletteOAuth2/Authorization/UserHelper.php
@@ -125,8 +125,14 @@ final class UserHelper
         '.' .
         self::stripAccents($nameFPart);
 
+        //check active member ?
         if (!$member->isActive()) {
             throw new UserAuthorizationException(_T('You are not an active member.', 'oauth2'));
+        }
+
+        //check email
+        if (!filter_var($member->email, FILTER_VALIDATE_EMAIL)) {
+            throw new UserAuthorizationException(_T("Sorry, you can't login. Please, add an email address to your account.", 'oauth2'));
         }
 
         //for options=

--- a/lib/GaletteOAuth2/Authorization/UserHelper.php
+++ b/lib/GaletteOAuth2/Authorization/UserHelper.php
@@ -233,7 +233,7 @@ final class UserHelper
             $options = array_merge($o, $options);
         }
         $options = array_unique($options);
-        Debug::Log('Options: ' . implode(';', $options));
+        Debug::log('Options: ' . implode(';', $options));
 
         return $options;
     }

--- a/lib/GaletteOAuth2/Controllers/ApiController.php
+++ b/lib/GaletteOAuth2/Controllers/ApiController.php
@@ -31,6 +31,7 @@ use GaletteOAuth2\Authorization\UserHelper;
 use GaletteOAuth2\Tools\Config;
 use GaletteOAuth2\Tools\Debug;
 use League\OAuth2\Server\ResourceServer;
+use RKA\Session;
 use Slim\Psr7\Request;
 use Slim\Psr7\Response;
 
@@ -49,6 +50,8 @@ final class ApiController extends AbstractPluginController
     protected array $module_info;
     protected Container $container;
     protected Config $config;
+    #[Inject("oauth_session")]
+    protected Session $session;
 
     // constructor receives container instance
     public function __construct(Container $container)

--- a/lib/GaletteOAuth2/Controllers/AuthorizationController.php
+++ b/lib/GaletteOAuth2/Controllers/AuthorizationController.php
@@ -34,6 +34,7 @@ use GaletteOAuth2\Tools\Debug as Debug;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use Psr\Http\Message\ResponseInterface;
+use RKA\Session;
 use Slim\Psr7\Request;
 use Slim\Psr7\Response;
 
@@ -52,6 +53,8 @@ final class AuthorizationController extends AbstractPluginController
     protected array $module_info;
     protected Container $container;
     protected Config $config;
+    #[Inject("oauth_session")]
+    protected Session $session;
 
     // constructor receives container instance
     public function __construct(Container $container)

--- a/lib/GaletteOAuth2/Controllers/LoginController.php
+++ b/lib/GaletteOAuth2/Controllers/LoginController.php
@@ -30,6 +30,7 @@ use GaletteOAuth2\Authorization\UserAuthorizationException;
 use GaletteOAuth2\Authorization\UserHelper;
 use GaletteOAuth2\Tools\Config;
 use GaletteOAuth2\Tools\Debug;
+use RKA\Session;
 use Slim\Psr7\Request;
 use Slim\Psr7\Response;
 
@@ -48,6 +49,8 @@ final class LoginController extends AbstractPluginController
     protected array $module_info;
     protected Container $container;
     protected Config $config;
+    #[Inject("oauth_session")]
+    protected Session $session;
 
     // constructor receives container instance
     public function __construct(Container $container)
@@ -96,7 +99,6 @@ final class LoginController extends AbstractPluginController
         //Try login
         $this->session->isLoggedIn = 'no';
         $this->session->user_id = $uid = UserHelper::login($this->container, $params['login'], $params['password']);
-        //if($params['login'] == 'manuel') $loginSuccessful = true;
         Debug::log("UserHelper::login({$params['login']}) return '{$uid}'");
 
         if (false === $uid) {

--- a/lib/GaletteOAuth2/Middleware/Authentication.php
+++ b/lib/GaletteOAuth2/Middleware/Authentication.php
@@ -45,7 +45,7 @@ final class Authentication
     public function __construct(Container $container)
     {
         $this->routeparser = $container->get(RouteParser::class);
-        $this->session = $container->get('session');
+        $this->session = $container->get('oauth_session');
     }
 
     /**

--- a/lib/GaletteOAuth2/Repositories/ClientRepository.php
+++ b/lib/GaletteOAuth2/Repositories/ClientRepository.php
@@ -46,7 +46,7 @@ final class ClientRepository implements ClientRepositoryInterface
     {
         $this->container = $container;
         $this->config = $this->container->get(Config::class);
-        $this->session = $this->container->get('session');
+        $this->session = $this->container->get('oauth_session');
     }
 
     public function getClientEntity($client_id)

--- a/lib/GaletteOAuth2/Tools/Debug.php
+++ b/lib/GaletteOAuth2/Tools/Debug.php
@@ -27,6 +27,7 @@ use Analog\Analog;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
+use Slim\Psr7\Request;
 
 /**
  * Debug tools
@@ -61,7 +62,7 @@ final class Debug
         );
     }
 
-    public static function logRequest($fct, $request): void
+    public static function logRequest(string $fct, Request $request): void
     {
         $msg = sprintf(
             "%s - URI: %s",
@@ -79,9 +80,5 @@ final class Debug
             $msg,
             Analog::DEBUG
         );
-        /*self::log("{$fct} :");
-        self::log('URI : ' . $request->getUri());
-        self::log('GET dump :' . self::printVar($request->getQueryParams()));
-        self::log('POST dump :' . self::printVar((array) $request->getParsedBody()));*/
     }
 }

--- a/lib/GaletteOAuth2/Tools/Debug.php
+++ b/lib/GaletteOAuth2/Tools/Debug.php
@@ -36,22 +36,6 @@ use Monolog\Logger;
  */
 final class Debug
 {
-    private static $logger;
-
-    public static function init(): Logger
-    {
-        self::$logger = new Logger('OAuth2');
-        $stream = new StreamHandler(GALETTE_LOGS_PATH . '/oauth.log', Logger::DEBUG);
-        $dateFormat = 'Y-m-d H:i:s';
-        //$output = "[%datetime%] %channel% %level_name%: %message% \n"; // %context% %extra%\n";
-        $output = "[%datetime%] : %message% \n"; // %context% %extra%\n";
-        $formatter = new LineFormatter($output, $dateFormat);
-        $stream->setFormatter($formatter);
-        self::$logger->pushHandler($stream);
-
-        return self::$logger;
-    }
-
     public static function printVar($expression, bool $return = true)
     {
         $export = print_r($expression, true);

--- a/templates/default/oauth2_login.html.twig
+++ b/templates/default/oauth2_login.html.twig
@@ -1,3 +1,4 @@
 {% extends "pages/index.html.twig" %}
 
+{% set ext_auth = true %}
 {% block form_url %}{{ url_for('oauth2_login') }}{% endblock %}

--- a/tests/GaletteOAuth2/Authorization/tests/units/UserHelper.php
+++ b/tests/GaletteOAuth2/Authorization/tests/units/UserHelper.php
@@ -79,7 +79,6 @@ class UserHelper extends GaletteTestCase
                 'city' => $adh1->town,
                 'phone' => $adh1->phone,
                 'status' => $adh1->status,
-                'state' => 'false',
                 'groups' => 'non-member'
             ],
             $user_data

--- a/tests/GaletteOAuth2/Authorization/tests/units/UserHelper.php
+++ b/tests/GaletteOAuth2/Authorization/tests/units/UserHelper.php
@@ -74,10 +74,10 @@ class UserHelper extends GaletteTestCase
                 'email' => $adh1->email,
                 'mail' => $adh1->email,
                 'language' => $adh1->language,
-                'country' => $adh1->country,
+                /*'country' => $adh1->country,
                 'zip' => $adh1->zipcode,
                 'city' => $adh1->town,
-                'phone' => $adh1->phone,
+                'phone' => $adh1->phone,*/
                 'status' => $adh1->status,
                 'groups' => 'non-member'
             ],


### PR DESCRIPTION
This way:
- existing loggedin user won't be used and won't be logged out
- no user will stay loggedin after oauth redirect

It's working quite well exept for flash messages... I have not been yet able to get them displayed correctly; they always are setup on the original session when they should be displayed :/